### PR TITLE
Toolbox integrity tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "type": "module",
   "scripts": {
-    "build": "node bin/buildDatabase.js",
-    "clear": "node bin/clearDatabase.js",
-    "test": "mocha lib/**/*.test.js",
+    "build":      "node bin/buildDatabase.js",
+    "clear":      "node bin/clearDatabase.js",
+    "test":       "mocha lib/**/*.test.js test/*.test.js",
     "test:build": "mocha lib/testBuild.js"
   },
   "bin": {

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,11 @@
+env:
+  mocha: true
+
+plugins:
+  - chai-friendly
+
+extends:
+  - plugin:chai-friendly/recommended
+
+rules:
+  camelcase: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,6 +1,9 @@
 env:
   mocha: true
 
+globals:
+  process: true
+
 plugins:
   - chai-friendly
 

--- a/test/toolbox.test.js
+++ b/test/toolbox.test.js
@@ -1,4 +1,5 @@
 // This file contains data integrity tests for the CW Toolbox database (Wolvengrey.toolbox).
+// These tests can only be run locally (because the database should not be checked into git).
 
 import createSpinner     from 'ora';
 import { expect }        from 'chai';
@@ -14,6 +15,11 @@ const __dirname    = getDirname(fileURLToPath(import.meta.url));
 const { readFile } = promises;
 
 describe('Toolbox database', function() {
+
+  if (process.env.GITHUB_ACTIONS) {
+    this.skip();
+    console.info('Skipping data integrity tests for CW Toolbox file on CI.');
+  }
 
   before(async function() {
     const databasePath = joinPath(__dirname, '../data/Wolvengrey.toolbox');

--- a/test/toolbox.test.js
+++ b/test/toolbox.test.js
@@ -16,14 +16,16 @@ const { readFile } = promises;
 
 describe('Toolbox database', function() {
 
-  if (process.env.GITHUB_ACTIONS) {
-    this.skip();
-    console.info('Skipping data integrity tests for CW Toolbox file on CI.');
-  }
-
   before(async function() {
+
+    if (process.env.GITHUB_ACTIONS) {
+      this.skip();
+      console.info('Skipping data integrity tests for CW Toolbox file on CI.');
+    }
+
     const databasePath = joinPath(__dirname, '../data/Wolvengrey.toolbox');
     this.text = await readFile(databasePath, 'utf8');
+
   });
 
   it('does not contain curly quotes or apostrophes', function() {

--- a/test/toolbox.test.js
+++ b/test/toolbox.test.js
@@ -1,5 +1,6 @@
 // This file contains data integrity tests for the CW Toolbox database (Wolvengrey.toolbox).
 
+import createSpinner     from 'ora';
 import { expect }        from 'chai';
 import { fileURLToPath } from 'url';
 import { promises }      from 'fs';
@@ -37,6 +38,24 @@ describe('Toolbox database', function() {
 
   it(`does not contain "3'"`, function() {
     expect(this.text).to.not.include(`3'`);
+  });
+
+  it('does not contain trailing semicolons at the ends of lines', function() {
+
+    this.timeout(10000);
+
+    const spinner = createSpinner('Checking for trailing semicolons.').start();
+
+    const lines = this.text
+    .split(/\r?\n/gu)
+    .map(line => line.trim());
+
+    for (const line of lines) {
+      expect(line.endsWith(';')).to.be.false;
+    }
+
+    spinner.succeed();
+
   });
 
 });

--- a/test/toolbox.test.js
+++ b/test/toolbox.test.js
@@ -35,4 +35,8 @@ describe('Toolbox database', function() {
 
   });
 
+  it(`does not contain "3'"`, function() {
+    expect(this.text).to.not.include(`3'`);
+  });
+
 });

--- a/test/toolbox.test.js
+++ b/test/toolbox.test.js
@@ -1,0 +1,38 @@
+// This file contains data integrity tests for the CW Toolbox database (Wolvengrey.toolbox).
+
+import { expect }        from 'chai';
+import { fileURLToPath } from 'url';
+import { promises }      from 'fs';
+
+import {
+  dirname as getDirname,
+  join    as joinPath,
+} from 'path';
+
+const __dirname    = getDirname(fileURLToPath(import.meta.url));
+const { readFile } = promises;
+
+describe('Toolbox database', function() {
+
+  before(async function() {
+    const databasePath = joinPath(__dirname, '../data/Wolvengrey.toolbox');
+    this.text = await readFile(databasePath, 'utf8');
+  });
+
+  it('does not contain curly quotes or apostrophes', function() {
+
+    const LEFT_SINGLE_QUOTATION_MARK  = '‘';
+    const RIGHT_SINGLE_QUOTATION_MARK = '’';
+    const LEFT_DOUBLE_QUOTATION_MARK  = '“';
+    const RIGHT_DOUBLE_QUOTATION_MARK = '”';
+
+    const { text } = this;
+
+    expect(text).to.not.include(LEFT_SINGLE_QUOTATION_MARK);
+    expect(text).to.not.include(RIGHT_SINGLE_QUOTATION_MARK);
+    expect(text).to.not.include(LEFT_DOUBLE_QUOTATION_MARK);
+    expect(text).to.not.include(RIGHT_DOUBLE_QUOTATION_MARK);
+
+  });
+
+});


### PR DESCRIPTION
closes #73

This PR adds a few tests to check the integrity of the data in the CW Toolbox file, following discussions with Arok. These tests can be run with `npx mocha test/toolbox.test.js`. Note that you need to have the Toolbox file saved in `data/Wolvengrey.toolbox` for these tests to run properly.