### PR TITLE
return empty string for empty lines

### DIFF
--- a/lib/utilities/readToolbox.js
+++ b/lib/utilities/readToolbox.js
@@ -84,7 +84,7 @@ export class ToolboxEntry {
    * @return {Object}       Returns an object with `type` (the line type, using the initial backslash code), `text`, and `index`.
    */
   static parseLine(line, index) {
-    const { text, type } = line.match(ToolboxEntry.lineCodeRegExp).groups;
+    const { text = ``, type } = line.match(ToolboxEntry.lineCodeRegExp).groups;
     return { index, text, type };
   }
 

--- a/lib/utilities/readToolbox.test.js
+++ b/lib/utilities/readToolbox.test.js
@@ -2,7 +2,9 @@ import {ToolboxEntry} from "./readToolbox.js";
 import {expect} from "chai";
 
 describe(`readToolbox`, function() {
+
   describe(`getLindexByType`, function() {
+
     it(`returns a list of sources when several are specified`, function() {
       const entry = new ToolboxEntry(`
         \\src A
@@ -11,21 +13,21 @@ describe(`readToolbox`, function() {
       expect(entry.getLinesByType(`src`)).to.eql([`A`, `B`]);
     });
 
-    it(`includes undefined in the list when no text is given`, function() {
+    it(`includes an empty string in the list when no text is given`, function() {
       const entry = new ToolboxEntry(`
         \\src A
         \\src
         \\src C
       `);
-      expect(entry.getLinesByType(`src`)).to.eql([`A`, undefined, `C`]);
+      expect(entry.getLinesByType(`src`)).to.eql([`A`, ``, `C`]);
     });
 
-    it(`returns [undefined] when there is only a single line of a given type, with no text`, function() {
+    it(`returns an empty string when there is only a single line of a given type, with no text`, function() {
       const entry = new ToolboxEntry(`
         \\stm
         \\src
       `);
-      expect(entry.getLinesByType(`stm`)).to.eql([undefined]);
+      expect(entry.getLinesByType(`stm`)).to.eql([``]);
     });
 
     it(`returns [] when the line type does not exist`, function() {
@@ -34,5 +36,7 @@ describe(`readToolbox`, function() {
       `);
       expect(entry.getLinesByType(`foo`)).to.eql([]);
     });
+
   });
+
 });

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   },
   "type": "module",
   "scripts": {
-    "aggregate": "node bin/aggregate.js data/database.ndjson data/database.ndjson",
-    "prebuild": "tsc && python lib/utilities/mini-lfs-client.py UAlbertaALTLab cree-intelligent-dictionary src/crkeng/resources/fst/crk-relaxed-analyzer-for-dictionary.hfstol",
-    "build": "node bin/buildDatabase.js",
-    "clear": "node bin/clearDatabase.js",
-    "test": "mocha lib/**/*.test.js test/*.test.js",
+    "aggregate":  "node bin/aggregate.js data/database.ndjson data/database.ndjson",
+    "prebuild":   "tsc && python lib/utilities/mini-lfs-client.py UAlbertaALTLab cree-intelligent-dictionary src/crkeng/resources/fst/crk-relaxed-analyzer-for-dictionary.hfstol",
+    "build":      "node bin/buildDatabase.js",
+    "clear":      "node bin/clearDatabase.js",
+    "pretest":    "tsc",
+    "test":       "mocha lib/**/*.test.js test/*.test.js",
     "test:build": "mocha lib/test/testBuild.js"
   },
   "bin": {


### PR DESCRIPTION
In `readToolbox.js`, the `parseLine` method now returns an empty string rather than `undefined` when a line has no text following the line marker.