### PR TITLE
FIX: source > sources

### DIFF
--- a/lib/aggregate/aggregate.test.js
+++ b/lib/aggregate/aggregate.test.js
@@ -55,9 +55,9 @@ describe(`aggregate entries`, function() {
       const sense2 = senses.find(sense => sense.definition === `s/he drags s.o. out of the water`);
       const sense3 = senses.find(sense => sense.definition === `He pulls him out of the fire or water.`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`CW`);
-      expect(sense3.source).to.equal(`MD`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`CW`]);
+      expect(sense3.sources).to.eql([`MD`]);
 
     });
 
@@ -70,8 +70,8 @@ describe(`aggregate entries`, function() {
       const sense1 = senses.find(sense => sense.definition === `s/he has a misconception`);
       const sense2 = senses.find(sense => sense.definition === `s/he is mistaken`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`CW`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`CW`]);
 
     });
 
@@ -84,8 +84,8 @@ describe(`aggregate entries`, function() {
       const sense1 = senses.find(sense => sense.definition === `squirrel`);
       const sense2 = senses.find(sense => sense.definition === `gopher`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`CW`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`CW`]);
 
     });
 
@@ -98,7 +98,7 @@ describe(`aggregate entries`, function() {
       const [sense] = senses;
 
       expect(sense.definition).to.equal(`s/he thinks more of s.t., s/he prefers s.t., s/he regards s.t. more highly, s/he favours s.t.`);
-      expect(sense.source).to.equal(`CW`);
+      expect(sense.sources).to.eql([`CW`]);
 
     });
 
@@ -111,8 +111,8 @@ describe(`aggregate entries`, function() {
       const sense1 = senses.find(sense => sense.definition === `s/he puts s.o. (s.w.), s/he places s.o.`);
       const sense2 = senses.find(sense => sense.definition === `s/he sets s.o. down`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`CW`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`CW`]);
 
     });
 
@@ -125,7 +125,7 @@ describe(`aggregate entries`, function() {
       const [sense] = senses;
 
       expect(sense.definition).to.equal(`s/he tells on s.o., s/he tattle on s.o., s/he rats on s.o.`);
-      expect(sense.source).to.equal(`CW`);
+      expect(sense.sources).to.eql([`CW`]);
 
     });
 
@@ -140,8 +140,8 @@ describe(`aggregate entries`, function() {
       const sense1 = senses.find(sense => sense.definition === `arrow, little arrow`);
       const sense2 = senses.find(sense => sense.definition === `An arrow.`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`MD`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`MD`]);
 
     });
 
@@ -156,7 +156,7 @@ describe(`aggregate entries`, function() {
       const [sense] = senses;
 
       expect(sense.definition).to.equal(`star, little star`);
-      expect(sense.source).to.equal(`CW`);
+      expect(sense.sources).to.eql([`CW`]);
 
     });
 
@@ -169,8 +169,8 @@ describe(`aggregate entries`, function() {
       const sense1 = senses.find(sense => sense.definition === `even, possibly`);
       const sense2 = senses.find(sense => sense.definition === `or, or else`);
 
-      expect(sense1.source).to.equal(`CW`);
-      expect(sense2.source).to.equal(`CW`);
+      expect(sense1.sources).to.eql([`CW`]);
+      expect(sense2.sources).to.eql([`CW`]);
 
     });
 
@@ -183,7 +183,7 @@ describe(`aggregate entries`, function() {
       const [sense] = senses;
 
       expect(sense.definition).to.equal(`s/he pastes s.t. on (the wall)`);
-      expect(sense.source).to.equal(`CW`);
+      expect(sense.sources).to.eql([`CW`]);
 
     });
 

--- a/lib/aggregate/index.js
+++ b/lib/aggregate/index.js
@@ -1,6 +1,6 @@
-import createSpinner from 'ora';
-import readNDJSON    from '../utilities/readNDJSON.js';
-import writeNDJSON   from '../utilities/writeNDJSON.js';
+import createSpinner   from 'ora';
+import readNDJSON      from '../utilities/readNDJSON.js';
+import writeNDJSON     from '../utilities/writeNDJSON.js';
 import assignParadigms from './paradigm-assignment.js';
 
 /**
@@ -34,7 +34,7 @@ function aggregateEntry(entry) {
 
   // SENSES
 
-  entry.senses = cw.senses.map(sense => Object.assign({ source: `CW` }, sense));
+  entry.senses = cw.senses.map(sense => Object.assign({ sources: [`CW`] }, sense));
 
   if (md?.mapping?.type) {
 
@@ -42,7 +42,7 @@ function aggregateEntry(entry) {
         // copy MD senses into main entry for these match types
         case `broad`:
         case `narrow`:
-          entry.senses.push(...md.senses.map(sense => Object.assign({ source: `MD` }, sense)));
+          entry.senses.push(...md.senses.map(sense => Object.assign({ sources: [`MD`] }, sense)));
           break;
         // do not copy MD senses into main entry for these match types
         case `conjugation`:

--- a/lib/aggregate/paradigm-assignment.ts
+++ b/lib/aggregate/paradigm-assignment.ts
@@ -215,11 +215,11 @@ export function inferAnalysis({
         throw Error("tie breaker exists but was not applied");
       }
     } else {
-      console.log(`${matches.length} matches for ${head}`);
+      // console.log(`${matches.length} matches for ${head}`);
       ok = false;
     }
   } else {
-    console.log(`${matches.length} matches for ${head}`);
+    // console.log(`${matches.length} matches for ${head}`);
     ok = false;
   }
 

--- a/lib/buildDatabase.js
+++ b/lib/buildDatabase.js
@@ -3,7 +3,7 @@
  */
 
 import aggregate         from './aggregate/index.js';
-import assignParadigms from "./aggregate/paradigm-assignment.js";
+import assignParadigms   from "./aggregate/paradigm-assignment.js";
 import clearDatabase     from './utilities/clearDatabase.js';
 import convertCW         from './convert/CW.js';
 import convertMD         from './convert/MD.js';
@@ -48,6 +48,7 @@ async function buildDatabase() {
   await withSpinner(`MD database import`,() => importMD(mdDataPath, databasePath));
   await withSpinner(`data source aggregation`, () => aggregate(databasePath, databasePath));
   await withSpinner(`paradigm assignment`, () =>  assignParadigms(databasePath, databasePath));
+
 }
 
 export default buildDatabase;

--- a/lib/utilities/readTSV.js
+++ b/lib/utilities/readTSV.js
@@ -10,7 +10,9 @@ import { createReadStream } from 'fs';
 export default async function readCSV(inputPath, options = {}) {
 
   const defaultOptions = {
-    columns:   true,
+    columns(header) {
+      return header.map(column => column.trim())
+    },
     delimiter: `\t`,
     relax:     true,
   };


### PR DESCRIPTION
I accidentally created a `sense.source` field rather than a `sense.sources` (plural) field in the aggregate database. This PR fixes that error.

This PR also fixes a problem where leading whitespace in the column header breaks the name of the first column.