### PR TITLE
remove literal meaning from semantic definition

### DIFF
--- a/lib/convert/dlx2importjson.js
+++ b/lib/convert/dlx2importjson.js
@@ -43,7 +43,7 @@ function convertEntry({
 
     const displayDefinition  = original;
     const coreDefinition     = definition.replace(/\s*\(.{3,}?\)\s*/gu, ` `).trim(); // strip any content in parentheses
-    const semanticDefinition = `${ coreDefinition } ${ literalMeaning }`.trim();
+    const semanticDefinition = coreDefinition.trim();
 
     const sense = {
       definition: displayDefinition,


### PR DESCRIPTION
The semantic definition was often including `undefined` in the text of the definition. This was caused by how the `semanticDefinition` property was being populated. It interpolated the core definition + literal definition, but without checking that the literal definition existed first.

Since the definition fields need to be overhauled, I simply removed the literal meaning from the semantic definition for the time being. It will be re-added when all the definition fields are updated.