### PR TITLE
fix regular expression for abbreviations

### DIFF
--- a/lib/convert/dlx2importjson.js
+++ b/lib/convert/dlx2importjson.js
@@ -261,18 +261,9 @@ function createSemanticDefinition(definition, { isPronoun, literalMeaning, notes
   }
 
   if (!isPronoun) {
-
-    // if (definition.includes(`s/he is a star`)) {
-    //   console.log(`\n`);
-    //   console.log(semanticDefinition);
-    //   console.log(semanticDefinition.replace(EnglishFunctionWordsRegExp, ``));
-    //   console.log(semanticDefinition.replace(EnglishAbbrevsRegExp, ``));
-    // }
-
     semanticDefinition = semanticDefinition
     .replace(EnglishFunctionWordsRegExp, ``) // issue is happening here
     .replace(EnglishAbbrevsRegExp, ``);      // or here
-
   }
 
   semanticDefinition = semanticDefinition

--- a/lib/convert/dlx2importjson.js
+++ b/lib/convert/dlx2importjson.js
@@ -31,9 +31,9 @@ const EnglishPronouns = new Set([
 ]);
 
 const EnglishAbbrevs = [
-  `s.o.`,
-  `s.t.`,
-  `s.w.`,
+  `s\\.o\\.`,
+  `s\\.t\\.`,
+  `s\\.w\\.`,
 ];
 
 const EnglishAbbrevsRegExp = new RegExp(`(${ EnglishAbbrevs.join(`|`) })`, `giu`);
@@ -239,6 +239,7 @@ function createSemanticDefinition(definition, { isPronoun, literalMeaning, notes
     if (latinNoteRegExp.test(parenText)) {
       const cleanedText = parenText.replace(latinNoteRegExp, ``);
       semanticDefinition = semanticDefinition.replace(parenthetical, cleanedText); // remove "e.g." and "i.e."
+      continue;
     }
 
     // remove all other parentheticals
@@ -260,9 +261,18 @@ function createSemanticDefinition(definition, { isPronoun, literalMeaning, notes
   }
 
   if (!isPronoun) {
+
+    // if (definition.includes(`s/he is a star`)) {
+    //   console.log(`\n`);
+    //   console.log(semanticDefinition);
+    //   console.log(semanticDefinition.replace(EnglishFunctionWordsRegExp, ``));
+    //   console.log(semanticDefinition.replace(EnglishAbbrevsRegExp, ``));
+    // }
+
     semanticDefinition = semanticDefinition
-    .replace(EnglishFunctionWordsRegExp, ``)
-    .replace(EnglishAbbrevsRegExp, ``);
+    .replace(EnglishFunctionWordsRegExp, ``) // issue is happening here
+    .replace(EnglishAbbrevsRegExp, ``);      // or here
+
   }
 
   semanticDefinition = semanticDefinition


### PR DESCRIPTION
When creating the semantic definitions, a regular expression is used to remove any 2-letter abbreviations followed by periods from the semantic definition. However, the periods in the regular expression weren't escaped properly, so a lot of text was being removed when it shouldn't be.

This PR escapes the periods in the regular expression so that it does the correct replacements now.